### PR TITLE
authors.js being loaded out of place

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,6 @@
   </main>
   {% include footer.html %}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/3.0.1/handlebars.min.js"></script>
-  <script src="js/author.js"></script>
   <script src="js/helpers.js"></script>
   <script src="js/main.js"></script>
 </body>

--- a/authors.html
+++ b/authors.html
@@ -1,6 +1,9 @@
 ---
 layout: default
 ---
+<!-- load authors info -->
+<script src="js/author.js"></script>
+
 <!-- the authors section shows the authors writing for of the website. -->
 <section class="authors" title="Authors writing on Latin Americans in Cryptography magazine">
 

--- a/js/author.js
+++ b/js/author.js
@@ -1,4 +1,4 @@
-window.onload = function() {
+var load_authors = function() {
   // get the template defined with handlebars and compile it.
   const source = document.getElementById("author-template").innerHTML;
   const template = Handlebars.compile(source);
@@ -90,3 +90,4 @@ window.onload = function() {
   const html = template(context);
   document.querySelector(".author-rendered-output").innerHTML = html;
 }
+window.addEventListener('load', load_authors, false);


### PR DESCRIPTION
Moving request for `authors.js` to authors page. It was being loaded in other pages, and failing due to not finding a nod with ID `#author-template`.
Also changed use of `window.onload` to `window.addEventListener('load',)` to avoid risk having multiple scripts overwrite `onload`.